### PR TITLE
Add install path

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -4,12 +4,12 @@
 #' @export
 #'
 #' @examples
-install <- function() {
+install <- function(path = "/usr/local/bin/curatedMetagenomicData") {
     source_file <-
         system.file("exec/curatedMetagenomicData", package = "curatedMetagenomicDataCLI")
 
     target_file <-
-        as.character("/usr/local/bin/curatedMetagenomicData")
+        as.character(path)
 
     system_link <-
         paste("ln -s", source_file, target_file)

--- a/R/install.R
+++ b/R/install.R
@@ -1,5 +1,12 @@
 #' Install the CLI
 #'
+#' Install the CLI along the default path or a custom path.
+#'
+#' If not installing along a `bin` path, you must add the path to $PATH. For
+#' example, `export PATH=/path/to/cli:$PATH`.
+#'
+#' @param path A string representing the installation path
+#'
 #' @return
 #' @export
 #'
@@ -15,4 +22,5 @@ install <- function(path = "/usr/local/bin/curatedMetagenomicData") {
         paste("ln -s", source_file, target_file)
 
     system(system_link)
+
 }

--- a/R/install.R
+++ b/R/install.R
@@ -22,5 +22,4 @@ install <- function(path = "/usr/local/bin/curatedMetagenomicData") {
         paste("ln -s", source_file, target_file)
 
     system(system_link)
-
 }

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -4,11 +4,18 @@
 \alias{install}
 \title{Install the CLI}
 \usage{
-install()
+install(path = "/usr/local/bin/curatedMetagenomicData")
+}
+\arguments{
+\item{path}{A string representing the installation path}
 }
 \value{
 
 }
 \description{
-Install the CLI
+Install the CLI along the default path or a custom path.
+}
+\details{
+If not installing along a \code{bin} path, you must add the path to $PATH. For
+example, \verb{export PATH=/path/to/my/cli:$PATH}.
 }


### PR DESCRIPTION
Currently, the CLI installs along `/usr/local/bin/curatedMetagenomicDataCLI`, which requires `sudo` permission. This PR allows the user to specify a path, so that they don't need `sudo` to install. 