### PR TITLE
Document lack of support for Coreutils < 8.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ Rscript -e 'BiocManager::install("waldronlab/curatedMetagenomicDataTerminal")'
 Rscript -e 'curatedMetagenomicDataTerminal::install()'
 ```
 
+### Ubuntu 18.04.06 LTS "Bionic Beaver" or other distributions with Coreutils < 8.30
+
+`curatedMetagenomicDataTerminal` does not currently work in Ubuntu 18.04.06 LTS or other 
+GNU/Linux distributions that ship with Coreutils < 8.30 that do not support `#!/usr/bin/env -S`. 
+With older versions of Coreutils, the following happens:
+
+```
+~$ curatedMetagenomicData -h
+/usr/bin/env: invalid option -- 'S'
+Try '/usr/bin/env --help' for more information.
+```
+
 ### MS Windows
 
 Do you have Windows and want to use curatedMetagenomicDataTerminal? The


### PR DESCRIPTION
Note that Ubuntu LTS 18.04 remains supported until 2023 so the issue will be around for a while (e.g. on wallabe4).